### PR TITLE
Fix markdown typo

### DIFF
--- a/accessibility/README.md
+++ b/accessibility/README.md
@@ -1,4 +1,4 @@
-﻿## Accessibility 
+# Accessibility 
 
 We want to make all Django Girls events as accessible as possible. Making your
 event accessible will help everyone, not just attendees with disabilities. This 


### PR DESCRIPTION
Had one typo in the markdown that was making the header render incorrectly.