### PR TITLE
Changed link to resources.

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -1,6 +1,6 @@
 # Resources
 
-All of our resources are available here: [resources.djangogirls.org](http://resources.djangogirls.org/).
+All of our resources are available here: [https://github.com/DjangoGirls/resources](https://github.com/DjangoGirls/resources).
 
 Inside you can find:
 - Logo in different versions (orange, white, square)


### PR DESCRIPTION
The previous link (resources.djangogirls.org) did not point to the resources, where as this one (https://github.com/DjangoGirls/resources) does. Hence, I propose a change here.